### PR TITLE
Feat/triangle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,5 +112,6 @@ endfunction()
 
 add_raytracer_plugin(raytracer_sphere source/Primitives/Sphere.cpp)
 add_raytracer_plugin(raytracer_plane source/Primitives/Plane.cpp)
+add_raytracer_plugin(raytracer_triangle source/Primitives/Triangle.cpp)
 add_raytracer_plugin(raytracer_ambientlight source/Light/AmbientLight.cpp)
 add_raytracer_plugin(raytracer_directionallight source/Light/DirectionalLight.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ endif()
 # Add libconfig++ to the global interface target
 if(LIBCONFIGXX_FOUND)
     target_include_directories(raytracerGlobal INTERFACE ${LIBCONFIGXX_INCLUDE_DIRS})
+    target_link_directories(raytracerGlobal INTERFACE ${LIBCONFIGXX_LIBRARY_DIRS})
     target_link_libraries(raytracerGlobal INTERFACE ${LIBCONFIGXX_LIBRARIES})
 else()
     target_link_libraries(raytracerGlobal INTERFACE config++)
@@ -85,45 +86,55 @@ file(GLOB_RECURSE CORE_FILES CONFIGURE_DEPENDS "source/*.cpp")
 
 list(FILTER CORE_FILES EXCLUDE REGEX "source/Primitives/.*\\.cpp$")
 list(FILTER CORE_FILES EXCLUDE REGEX "source/Light/.*\\.cpp$")
+set(CORE_EXEC_FILES ${CORE_FILES})
+list(FILTER CORE_EXEC_FILES EXCLUDE REGEX "source/main\\.cpp$")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-add_executable(raytracer ${CORE_FILES})
-target_link_libraries(raytracer PRIVATE raytracerGlobal)
+add_library(raytracer_core STATIC ${CORE_EXEC_FILES})
+target_link_libraries(raytracer_core PRIVATE raytracerGlobal)
+
+add_executable(raytracer source/main.cpp)
+target_link_libraries(raytracer PRIVATE raytracerGlobal raytracer_core)
 set_target_properties(raytracer PROPERTIES ENABLE_EXPORTS TRUE)
 
 # === PLUGINS ===
 set(PLUGIN_DIR "${PROJECT_SOURCE_DIR}/plugins")
 file(MAKE_DIRECTORY ${PLUGIN_DIR})
+set(PLUGIN_SUFFIX ".so")
 
 # Sphere
 add_library(raytracer_sphere SHARED source/Primitives/Sphere.cpp)
-target_link_libraries(raytracer_sphere PRIVATE raytracerGlobal)
+target_link_libraries(raytracer_sphere PRIVATE raytracerGlobal raytracer_core)
 set_target_properties(raytracer_sphere PROPERTIES
     PREFIX ""
+    SUFFIX ${PLUGIN_SUFFIX}
     LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR}
 )
 
 # Plane
 add_library(raytracer_plane SHARED source/Primitives/Plane.cpp)
-target_link_libraries(raytracer_plane PRIVATE raytracerGlobal)
+target_link_libraries(raytracer_plane PRIVATE raytracerGlobal raytracer_core)
 set_target_properties(raytracer_plane PROPERTIES
     PREFIX ""
+    SUFFIX ${PLUGIN_SUFFIX}
     LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR}
 )
 
 # AmbientLight
 add_library(raytracer_ambientlight SHARED source/Light/AmbientLight.cpp)
-target_link_libraries(raytracer_ambientlight PRIVATE raytracerGlobal)
+target_link_libraries(raytracer_ambientlight PRIVATE raytracerGlobal raytracer_core)
 set_target_properties(raytracer_ambientlight PROPERTIES
     PREFIX ""
+    SUFFIX ${PLUGIN_SUFFIX}
     LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR}
 )
 
 # DirectionalLight
 add_library(raytracer_directionallight SHARED source/Light/DirectionalLight.cpp)
-target_link_libraries(raytracer_directionallight PRIVATE raytracerGlobal)
+target_link_libraries(raytracer_directionallight PRIVATE raytracerGlobal raytracer_core)
 set_target_properties(raytracer_directionallight PROPERTIES
     PREFIX ""
+    SUFFIX ${PLUGIN_SUFFIX}
     LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR}
 )
 add_compile_options(-Wold-style-cast)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20...4.0)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(Raytracer LANGUAGES CXX)
 
 # === GLOBAL CONFIGURATION ===
@@ -14,7 +14,7 @@ find_package(PkgConfig QUIET)
 add_library(raytracerGlobal INTERFACE)
 
 target_compile_options(raytracerGlobal INTERFACE
-    -Wall -Wextra -Werror -Wpedantic
+    -Wall -Wextra -Werror -Wpedantic -Wold-style-cast
 )
 
 target_include_directories(raytracerGlobal INTERFACE
@@ -30,11 +30,13 @@ target_include_directories(raytracerGlobal INTERFACE
 
 # === DEPENDENCIES: LIBCONFIG++ ===
 if(PKG_CONFIG_FOUND)
-    pkg_check_modules(LIBCONFIGXX QUIET libconfig++)
+    pkg_check_modules(LIBCONFIGXX QUIET IMPORTED_TARGET libconfig++)
 endif()
 
 if(NOT LIBCONFIGXX_FOUND)
     message(STATUS "libconfig++ not found, fetching from GitHub...")
+
+    set(CMAKE_POLICY_VERSION_MINIMUM "3.5" CACHE STRING "Minimum policy version" FORCE)
 
     set(BUILD_EXAMPLES OFF CACHE BOOL "Disable libconfig examples" FORCE)
     set(BUILD_TESTS OFF CACHE BOOL "Disable libconfig tests" FORCE)
@@ -72,69 +74,43 @@ else()
 endif()
 
 # Add libconfig++ to the global interface target
-if(LIBCONFIGXX_FOUND)
-    target_include_directories(raytracerGlobal INTERFACE ${LIBCONFIGXX_INCLUDE_DIRS})
-    target_link_directories(raytracerGlobal INTERFACE ${LIBCONFIGXX_LIBRARY_DIRS})
-    target_link_libraries(raytracerGlobal INTERFACE ${LIBCONFIGXX_LIBRARIES})
+if(TARGET PkgConfig::LIBCONFIGXX)
+    target_link_libraries(raytracerGlobal INTERFACE PkgConfig::LIBCONFIGXX)
 else()
+    # Fallback pour la version FetchContent
     target_link_libraries(raytracerGlobal INTERFACE config++)
     target_include_directories(raytracerGlobal INTERFACE ${libconfig_SOURCE_DIR}/lib)
 endif()
 
 # === PROJECT CORE ===
 file(GLOB_RECURSE CORE_FILES CONFIGURE_DEPENDS "source/*.cpp")
-
 list(FILTER CORE_FILES EXCLUDE REGEX "source/Primitives/.*\\.cpp$")
 list(FILTER CORE_FILES EXCLUDE REGEX "source/Light/.*\\.cpp$")
-set(CORE_EXEC_FILES ${CORE_FILES})
-list(FILTER CORE_EXEC_FILES EXCLUDE REGEX "source/main\\.cpp$")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-add_library(raytracer_core STATIC ${CORE_EXEC_FILES})
-target_link_libraries(raytracer_core PRIVATE raytracerGlobal)
 
-add_executable(raytracer source/main.cpp)
-target_link_libraries(raytracer PRIVATE raytracerGlobal raytracer_core)
+add_executable(raytracer ${CORE_FILES})
+target_link_libraries(raytracer PRIVATE raytracerGlobal)
 set_target_properties(raytracer PROPERTIES ENABLE_EXPORTS TRUE)
 
 # === PLUGINS ===
-set(PLUGIN_DIR "${PROJECT_SOURCE_DIR}/plugins")
-file(MAKE_DIRECTORY ${PLUGIN_DIR})
-set(PLUGIN_SUFFIX ".so")
+set(PLUGIN_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/plugins)
 
-# Sphere
-add_library(raytracer_sphere SHARED source/Primitives/Sphere.cpp)
-target_link_libraries(raytracer_sphere PRIVATE raytracerGlobal raytracer_core)
-set_target_properties(raytracer_sphere PROPERTIES
-    PREFIX ""
-    SUFFIX ${PLUGIN_SUFFIX}
-    LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR}
-)
+function(add_raytracer_plugin target_name source_file)
+    add_library(${target_name} MODULE ${source_file})
+    target_link_libraries(${target_name} PRIVATE raytracerGlobal)
 
-# Plane
-add_library(raytracer_plane SHARED source/Primitives/Plane.cpp)
-target_link_libraries(raytracer_plane PRIVATE raytracerGlobal raytracer_core)
-set_target_properties(raytracer_plane PROPERTIES
-    PREFIX ""
-    SUFFIX ${PLUGIN_SUFFIX}
-    LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR}
-)
+    set_target_properties(${target_name} PROPERTIES
+        PREFIX ""
+        LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_OUTPUT_DIR}
+    )
 
-# AmbientLight
-add_library(raytracer_ambientlight SHARED source/Light/AmbientLight.cpp)
-target_link_libraries(raytracer_ambientlight PRIVATE raytracerGlobal raytracer_core)
-set_target_properties(raytracer_ambientlight PROPERTIES
-    PREFIX ""
-    SUFFIX ${PLUGIN_SUFFIX}
-    LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR}
-)
+    if(APPLE)
+        set_target_properties(${target_name} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    endif()
+endfunction()
 
-# DirectionalLight
-add_library(raytracer_directionallight SHARED source/Light/DirectionalLight.cpp)
-target_link_libraries(raytracer_directionallight PRIVATE raytracerGlobal raytracer_core)
-set_target_properties(raytracer_directionallight PROPERTIES
-    PREFIX ""
-    SUFFIX ${PLUGIN_SUFFIX}
-    LIBRARY_OUTPUT_DIRECTORY ${PLUGIN_DIR}
-)
-add_compile_options(-Wold-style-cast)
+add_raytracer_plugin(raytracer_sphere source/Primitives/Sphere.cpp)
+add_raytracer_plugin(raytracer_plane source/Primitives/Plane.cpp)
+add_raytracer_plugin(raytracer_ambientlight source/Light/AmbientLight.cpp)
+add_raytracer_plugin(raytracer_directionallight source/Light/DirectionalLight.cpp)

--- a/include/Primitives/Triangle.hpp
+++ b/include/Primitives/Triangle.hpp
@@ -1,0 +1,32 @@
+/*
+** EPITECH PROJECT, 2026
+** Raytracer
+** File description:
+** Triangle
+*/
+
+/// @file Triangle.hpp
+/// @brief Triangle class definition
+
+#pragma once
+
+#include "IPrimitive.hpp"
+#include "Point3D.hpp"
+
+/// @brief Namespace for the RayTracer project
+namespace RayTrace {
+    using Point3D = Math::Point3D<double>;
+    using Vector3D = Math::Vector3D<double>;
+
+    /// @brief Represents a triangle in 3D space
+    class Triangle : public IPrimitive {
+        public:
+        Triangle() = default;
+        /// @brief Constructs a Triangle object
+        /// @param v0 The first vertex of the triangle
+        /// @param v1 The second vertex of the triangle
+        /// @param v2 The third vertex of the triangle
+        Triangle(const Point3D& v0, const Point3D& v1, const Point3D& v2);
+        
+    };
+} // namespace RayTracer

--- a/include/Primitives/Triangle.hpp
+++ b/include/Primitives/Triangle.hpp
@@ -14,7 +14,7 @@
 #include "Point3D.hpp"
 
 /// @brief Namespace for the RayTracer project
-namespace RayTrace {
+namespace RayTracer {
     using Point3D = Math::Point3D<double>;
     using Vector3D = Math::Vector3D<double>;
 
@@ -27,6 +27,13 @@ namespace RayTrace {
         /// @param v1 The second vertex of the triangle
         /// @param v2 The third vertex of the triangle
         Triangle(const Point3D& v0, const Point3D& v1, const Point3D& v2);
+
+        Point3D _v0;
+        Point3D _v1;
+        Point3D _v2;
+
+        [[nodiscard]] bool hits(const Ray& ray, HitRecord& hitRecord) const override;
         
+        void init(const libconfig::Setting& setting) override;
     };
 } // namespace RayTracer

--- a/include/Primitives/Triangle.hpp
+++ b/include/Primitives/Triangle.hpp
@@ -28,12 +28,22 @@ namespace RayTracer {
         /// @param v2 The third vertex of the triangle
         Triangle(const Point3D& v0, const Point3D& v1, const Point3D& v2);
 
+        /// @brief The three vertices of the triangle
         Point3D _v0;
         Point3D _v1;
         Point3D _v2;
 
+
+        /// @brief Determines if a ray intersects the triangle and fills the hit record with
+        /// intersection details
+        /// @param ray The ray to test for intersection with the triangle
+        /// @param hitRecord The hit record to be filled with intersection details if the ray hits
+        /// the triangle
+        /// @return True if the ray intersects the triangle, false otherwise
         [[nodiscard]] bool hits(const Ray& ray, HitRecord& hitRecord) const override;
         
+        /// @brief Initializes the triangle with settings from a configuration file
+        /// @param setting The configuration settings for the triangle
         void init(const libconfig::Setting& setting) override;
     };
 } // namespace RayTracer

--- a/scenes/scene_triangle.cfg
+++ b/scenes/scene_triangle.cfg
@@ -1,0 +1,19 @@
+camera:
+{
+    resolution = { width = 400; height = 400; };
+    position = { x = 0.0; y = 0.0; z = 0.0; };
+    rotation = { x = 0.0; y = 0.0; z = 0.0; };
+    fieldOfView = 72.0;
+};
+
+primitives:
+{
+    triangles = (
+        {
+            v0 = { x = -1.0; y = -1.0; z = 3.0; };
+            v1 = { x =  1.0; y = -1.0; z = 3.0; };
+            v2 = { x =  0.0; y =  1.0; z = 3.0; };
+            color = { r = 255; g = 0; b = 0; };
+        }
+    );
+};

--- a/source/Primitives/Triangle.cpp
+++ b/source/Primitives/Triangle.cpp
@@ -79,6 +79,19 @@ bool RayTracer::Triangle::hits(const Ray& ray, HitRecord& rec) const
     // Vérifie que l'intersection est devant la caméra
     if (t <= epsilon) return false;
 
+    // Remplir le HitRecord
+    rec.distance = t;
+    rec.p = ray._origin + (ray._direction * t);
+
+    // Calculer la normale du triangle
+    Vector3D normal(
+        edge1._y * edge2._z - edge1._z * edge2._y,
+        edge1._z * edge2._x - edge1._x * edge2._z,
+        edge1._x * edge2._y - edge1._y * edge2._x
+    );
+    rec.normal = normal.normalized();
+
+    return true;
 }
 
 extern "C" {

--- a/source/Primitives/Triangle.cpp
+++ b/source/Primitives/Triangle.cpp
@@ -94,6 +94,55 @@ bool RayTracer::Triangle::hits(const Ray& ray, HitRecord& rec) const
     return true;
 }
 
+void RayTracer::Triangle::init(const libconfig::Setting& setting)
+{
+    if (setting.exists("v0")) {
+        const libconfig::Setting& v0 = setting["v0"];
+        double x = 0.0;
+        double y = 0.0;
+        double z = 0.0;
+        ConfigUtils::getAsDouble(v0, "x", x);
+        ConfigUtils::getAsDouble(v0, "y", y);
+        ConfigUtils::getAsDouble(v0, "z", z);
+        _v0 = Point3D(x, y, z);
+    }
+
+    if (setting.exists("v1")) {
+        const libconfig::Setting& v1 = setting["v1"];
+        double x = 0.0;
+        double y = 0.0;
+        double z = 0.0;
+        ConfigUtils::getAsDouble(v1, "x", x);
+        ConfigUtils::getAsDouble(v1, "y", y);
+        ConfigUtils::getAsDouble(v1, "z", z);
+        _v1 = Point3D(x, y, z);
+    }
+
+    if (setting.exists("v2")) {
+        const libconfig::Setting& v2 = setting["v2"];
+        double x = 0.0;
+        double y = 0.0;
+        double z = 0.0;
+        ConfigUtils::getAsDouble(v2, "x", x);
+        ConfigUtils::getAsDouble(v2, "y", y);
+        ConfigUtils::getAsDouble(v2, "z", z);
+        _v2 = Point3D(x, y, z);
+    }
+
+    if (setting.exists("color")) {
+        const libconfig::Setting& c = setting["color"];
+        double r = 255.0;
+        double g = 255.0;
+        double b = 255.0;
+        ConfigUtils::getAsDouble(c, "r", r);
+        ConfigUtils::getAsDouble(c, "g", g);
+        ConfigUtils::getAsDouble(c, "b", b);
+        color._x = static_cast<int>(r);
+        color._y = static_cast<int>(g);
+        color._z = static_cast<int>(b);
+    }
+}
+
 extern "C" {
 RayTracer::IPrimitive* entryPoint() { return new RayTracer::Triangle(); }
 }

--- a/source/Primitives/Triangle.cpp
+++ b/source/Primitives/Triangle.cpp
@@ -74,6 +74,11 @@ bool RayTracer::Triangle::hits(const Ray& ray, HitRecord& rec) const
     // "v" en dehors du triangle
     if (v < 0.0 || u + v > 1.0) return false;
 
+    double t = edge2.dot(qvec) * invDet;
+
+    // Vérifie que l'intersection est devant la caméra
+    if (t <= epsilon) return false;
+
 }
 
 extern "C" {

--- a/source/Primitives/Triangle.cpp
+++ b/source/Primitives/Triangle.cpp
@@ -57,6 +57,23 @@ bool RayTracer::Triangle::hits(const Ray& ray, HitRecord& rec) const
     // "det" proche de 0 = rayon parallèle au triangle
     if (std::abs(det) < epsilon) return false;
 
+    double invDet = 1.0 / det;
+
+    Vector3D tvec = ray._origin - _v0;
+    double u = tvec.dot(pvec) * invDet;
+
+    // "u" en dehors du triangle
+    if (u < 0.0 || u > 1.0) return false;
+
+    Vector3D qvec(
+        tvec._y * edge1._z - tvec._z * edge1._y,
+        tvec._z * edge1._x - tvec._x * edge1._z,
+        tvec._x * edge1._y - tvec._y * edge1._x
+    );
+    double v = ray._direction.dot(qvec) * invDet;
+    // "v" en dehors du triangle
+    if (v < 0.0 || u + v > 1.0) return false;
+
 }
 
 extern "C" {

--- a/source/Primitives/Triangle.cpp
+++ b/source/Primitives/Triangle.cpp
@@ -16,7 +16,32 @@
 #include "ConfigUtils.hpp"
 #include "RayTracerException.hpp"
 
-RayTracer::Triangle::Triangle(const Point3D& v0, const Point3D& v1, const Point3D& v2)
+RayTracer::Triangle::Triangle(
+    const Point3D& v0, const Point3D& v1, const Point3D& v2) :
+    _v0(v0), _v1(v1), _v2(v2)
 {
+    if (v0._x == v1._x && v0._y == v1._y && v0._z == v1._z)
+        throw RayTracer::RayTracerException("Triangle: Vertices cannot be the same point.");
+    if (v0._x == v2._x && v0._y == v2._y && v0._z == v2._z)
+        throw RayTracer::RayTracerException("Triangle: Vertices cannot be the same point.");
+    if (v1._x == v2._x && v1._y == v2._y && v1._z == v2._z)
+        throw RayTracer::RayTracerException("Triangle: Vertices cannot be the same point.");
     
+    Vector3D edge1 = v1 - v0;
+    Vector3D edge2 = v2 - v0;
+    Vector3D normal(
+        edge1._y * edge2._z - edge1._z * edge2._y,
+        edge1._z * edge2._x - edge1._x * edge2._z,
+        edge1._x * edge2._y - edge1._y * edge2._x);
+
+    if (normal._x == 0.0 && normal._y == 0.0 && normal._z == 0.0)
+        throw RayTracer::RayTracerException("Triangle: Vertices cannot be collinear.");
+}
+
+bool RayTracer::Triangle::hits(const Ray& ray, HitRecord& rec) const
+{
+}
+
+extern "C" {
+RayTracer::IPrimitive* entryPoint() { return new RayTracer::Triangle(); }
 }

--- a/source/Primitives/Triangle.cpp
+++ b/source/Primitives/Triangle.cpp
@@ -40,6 +40,23 @@ RayTracer::Triangle::Triangle(
 
 bool RayTracer::Triangle::hits(const Ray& ray, HitRecord& rec) const
 {
+    const double epsilon = 1e-6;
+
+    //Calcul des arêtes
+    Vector3D edge1 = _v1 - _v0;
+    Vector3D edge2 = _v2 - _v0;
+
+    Vector3D pvec(
+        ray._direction._y * edge2._z - ray._direction._z * edge2._y,
+        ray._direction._z * edge2._x - ray._direction._x * edge2._z,
+        ray._direction._x * edge2._y - ray._direction._y * edge2._x
+    );
+
+    double det = edge1.dot(pvec);
+
+    // "det" proche de 0 = rayon parallèle au triangle
+    if (std::abs(det) < epsilon) return false;
+
 }
 
 extern "C" {

--- a/source/Primitives/Triangle.cpp
+++ b/source/Primitives/Triangle.cpp
@@ -1,0 +1,22 @@
+/*
+** EPITECH PROJECT, 2026
+** Raytracer
+** File description:
+** Triangle
+*/
+
+/// @file Triangle.cpp
+/// @brief Implementation of the Triangle class.
+
+#include "Triangle.hpp"
+
+#include <cmath>
+#include <memory>
+
+#include "ConfigUtils.hpp"
+#include "RayTracerException.hpp"
+
+RayTracer::Triangle::Triangle(const Point3D& v0, const Point3D& v1, const Point3D& v2)
+{
+    
+}


### PR DESCRIPTION
# Triangle - Implémentation

## Description

La primitive **Triangle** a été implémentée pour le raytracer. Elle permet de tracer des triangles en 3D dans la scène.

## Méthode d'intersection

L'intersection rayon-triangle utilise l'**algorithme de Möller-Trumbore**, une méthode très efficace et largement utilisée en ray tracing. Cet algorithme calcule directement l'intersection sans passer par une étape intermédiaire rayon-plan, ce qui le rend plus rapide et numériquement stable.

### Étapes de l'algorithme :
1. Calcul des deux arêtes du triangle (edge1 et edge2)
2. Calcul du déterminant pour vérifier si le rayon est parallèle
3. Calcul des coordonnées barycentriques (u, v) du point d'intersection
4. Vérification que le point se trouve à l'intérieur du triangle
5. Calcul de la distance t entre l'origine du rayon et le point d'intersection
6. Calcul de la normale du triangle pour l'éclairage

## Utilisation

Pour utiliser un triangle dans une scène, il faut l'ajouter dans le bloc `triangles` du fichier de configuration :

```cfg
primitives:
{
    triangles = (
        {
            v0 = { x = -1.0; y = -1.0; z = 3.0; };
            v1 = { x =  1.0; y = -1.0; z = 3.0; };
            v2 = { x =  0.0; y =  1.0; z = 3.0; };
            color = { r = 255; g = 0; b = 0; };
        }
    );
};
```

## Paramètres

- `v0`, `v1`, `v2` : Les trois sommets du triangle en 3D (x, y, z)
- `color` : La couleur RGB du triangle (0-255 pour chaque canal)

## Validations

Le triangle valide automatiquement que :
- Les trois sommets ne sont pas identiques
- Les trois sommets ne sont pas collinéaires (ne forment pas une ligne)
