### PR TITLE
add(multi threading): works!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ target_include_directories(raytracerGlobal INTERFACE
     ${PROJECT_SOURCE_DIR}/include/Loader
 )
 
+# === Add OpenMP library ===
+find_package(OpenMP REQUIRED)
+target_link_libraries(raytracerGlobal INTERFACE OpenMP::OpenMP_CXX)
+
 # === DEPENDENCIES: LIBCONFIG++ ===
 if(PKG_CONFIG_FOUND)
     pkg_check_modules(LIBCONFIGXX QUIET IMPORTED_TARGET libconfig++)

--- a/include/Core/Renderer.hpp
+++ b/include/Core/Renderer.hpp
@@ -88,6 +88,11 @@ namespace RayTracer {
             const Ray& ray, int depth, const std::vector<std::unique_ptr<IPrimitive>>& primitives,
             const std::vector<std::unique_ptr<ILight>>& lights) const;
 
+        void computeRows(const Camera& camera,
+                         const std::vector<std::unique_ptr<IPrimitive>>& primitives,
+                         const std::vector<std::unique_ptr<ILight>>& lights,
+                         std::vector<uint8_t>& fullBuffer) const;
+
         /// @brief Writes the color of a pixel to the output stream
         /// @param out The output stream to write the color to
         /// @param color The color to write

--- a/include/Materials/MaterialUtils.hpp
+++ b/include/Materials/MaterialUtils.hpp
@@ -19,8 +19,8 @@ namespace RayTracer {
         public:
         static double randomDouble()
         {
-            static std::uniform_real_distribution<double> distribution(0.0, 1.0);
-            static std::mt19937 generator;
+            thread_local std::uniform_real_distribution<double> distribution(0.0, 1.0);
+            thread_local std::mt19937 generator;
             return distribution(generator);
         }
 

--- a/scenes/scene_fractal.cfg
+++ b/scenes/scene_fractal.cfg
@@ -2,7 +2,7 @@ renderer:
 {
     resolution = { width = 1000; height = 1000; };
     background = "sky";
-    samples = 3;
+    samples = 15;
 };
 
 camera:
@@ -63,7 +63,7 @@ primitives:
             rotation = { x = -45.0; y = 0.0; z = -45.0 };
             scale = 2.0;
             iterations = 50;
-            material = "mat_255_0_255";
+            material = "mat_0_0_255";
         }
     );
 };

--- a/source/Core/Renderer.cpp
+++ b/source/Core/Renderer.cpp
@@ -10,6 +10,8 @@
 
 #include "Renderer.hpp"
 
+#include <omp.h>
+
 #include <fstream>
 
 #include "ConfigUtils.hpp"
@@ -33,24 +35,15 @@ void RayTracer::Renderer::init(const libconfig::Setting& setting)
     setting.lookupValue("maxDepth", _maxDepth);
 }
 
-void RayTracer::Renderer::render(const Camera& camera,
-                                 const std::vector<std::unique_ptr<IPrimitive>>& primitives,
-                                 const std::vector<std::unique_ptr<ILight>>& lights,
-                                 const std::string& filename) const
+void RayTracer::Renderer::computeRows(const Camera& camera,
+                                      const std::vector<std::unique_ptr<IPrimitive>>& primitives,
+                                      const std::vector<std::unique_ptr<ILight>>& lights,
+                                      std::vector<uint8_t>& fullBuffer) const
 {
-    std::ofstream outFile(filename);
-    if (!outFile.is_open())
-        throw RayTracerException("Renderer: Cannot open output file " + filename);
-
-    outFile << "P6\n" << _width << ' ' << _height << "\n255\n";
-
     double ratio = static_cast<double>(_width) / _height;
 
-    std::vector<uint8_t> buffer;
-    buffer.reserve(_width * 3);
-
+#pragma omp parallel for schedule(dynamic, 8) collapse(2)
     for (int y = _height - 1; y >= 0; y--) {
-        buffer.clear();
         for (int x = 0; x < _width; x++) {
             Math::Vector3D<double> pixelColor(0.0, 0.0, 0.0);
             for (int s = 0; s < _samples; s++) {
@@ -60,13 +53,31 @@ void RayTracer::Renderer::render(const Camera& camera,
                 pixelColor += computeRayColor(r, _maxDepth, primitives, lights);
             }
             pixelColor = pixelColor / static_cast<double>(_samples);
-            buffer.push_back(static_cast<uint8_t>(std::clamp(pixelColor._x, 0.0, 255.0)));
-            buffer.push_back(static_cast<uint8_t>(std::clamp(pixelColor._y, 0.0, 255.0)));
-            buffer.push_back(static_cast<uint8_t>(std::clamp(pixelColor._z, 0.0, 255.0)));
-        }
-        outFile.write(reinterpret_cast<const char*>(buffer.data()), buffer.size());
-    }
 
+            int row = (_height - 1 - y);
+            int idx = (row * _width + x) * 3;
+            fullBuffer[idx] = static_cast<uint8_t>(std::clamp(pixelColor._x, 0.0, 255.0));
+            fullBuffer[idx + 1] = static_cast<uint8_t>(std::clamp(pixelColor._y, 0.0, 255.0));
+            fullBuffer[idx + 2] = static_cast<uint8_t>(std::clamp(pixelColor._z, 0.0, 255.0));
+        }
+    }
+}
+
+void RayTracer::Renderer::render(const Camera& camera,
+                                 const std::vector<std::unique_ptr<IPrimitive>>& primitives,
+                                 const std::vector<std::unique_ptr<ILight>>& lights,
+                                 const std::string& filename) const
+{
+    std::vector<uint8_t> fullBuffer(_width * _height * 3);
+    std::ofstream outFile(filename);
+
+    if (!outFile.is_open())
+        throw RayTracerException("Renderer: Cannot open output file " + filename);
+
+    outFile << "P6\n" << _width << ' ' << _height << "\n255\n";
+    computeRows(camera, primitives, lights, fullBuffer);
+
+    outFile.write(reinterpret_cast<const char*>(fullBuffer.data()), fullBuffer.size());
     outFile.close();
 }
 


### PR DESCRIPTION
## Add OpenMP multithreading

Added OpenMP parallelism to the rendering loop to improve performance.

### Changes
- Render loop (`computeRows`) is now parallelized with `#pragma omp parallel for schedule(dynamic, 8) collapse(2)` — each pixel is computed independently across all CPU cores
- `fullBuffer` is pre-allocated before the parallel section, each thread writes to its own disjoint index range with no race condition
- `MaterialUtils::randomDouble()` updated to use `thread_local` RNG — was using a shared `static` state, which was not thread-safe
- OpenMP linked via CMake: `find_package(OpenMP REQUIRED)` + `target_link_libraries(raytracerGlobal INTERFACE OpenMP::OpenMP_CXX)`